### PR TITLE
Only set long expiration for files in _app/immutable directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,10 +76,15 @@ export default function entrypoint() {
         ...prerenderedPages,
         ...prerenderedRedirects,
         {
+          url: `/${builder.config.kit.appDir}/immutable/`,
+          // eslint-disable-next-line camelcase
+          static_dir: `storage/${builder.config.kit.appDir}/immutable`,
+          expiration: '30d 0h',
+        },
+        {
           url: `/${builder.config.kit.appDir}/`,
           // eslint-disable-next-line camelcase
           static_dir: `storage/${builder.config.kit.appDir}`,
-          expiration: '30d 0h',
         },
         {
           url: '/.*',

--- a/tests/expected_app.yaml
+++ b/tests/expected_app.yaml
@@ -11,9 +11,11 @@ handlers:
   - url: /about/?$
     static_files: storage/about.html
     upload: storage/about.html
+  - url: /_app/immutable/
+    static_dir: storage/_app/immutable
+    expiration: 30d 0h
   - url: /_app/
     static_dir: storage/_app
-    expiration: 30d 0h
   - url: /.*
     secure: always
     script: auto


### PR DESCRIPTION
Recently SvelteKit introduced the `_app/immutable` directory in the buildout. This directory contains all files that should be cached with a long TTL. Serving the whole `_app/` directory with a long TTL impacts the SvelteKit update check via the `updated` store from `$app/stores` (see: https://kit.svelte.dev/docs/modules#$app-stores-updated) which relies on being able to fetch the current app version from `_app/version.json`.

This PR splits the handlers for `_app/` and `_app/immutable` and only sets the 30d expiration on the `_app/immutable` handler. Other assets in `_app/` are then served with the default expiration which can further be customized by setting `default_expiration` in the top-level `app.yaml`.

Similar changes in the default adapters were introduced in https://github.com/sveltejs/kit/pull/5051