### PR TITLE
fix: Remove compression from serving

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import {installPolyfills} from '@sveltejs/kit/node/polyfills';
 import {getRequest, setResponse} from '@sveltejs/kit/node';
-import compression from 'compression';
 import {manifest} from 'MANIFEST';
 import polka from 'polka';
 import sirv from 'sirv';
@@ -50,7 +49,7 @@ const kitMiddleware = createKitMiddleware();
 
 const server = polka()
   .use(staticServe)
-  .use(compression({threshold: 0}), kitMiddleware);
+  .use(kitMiddleware);
 
 const port = process.env.PORT || 8080;
 const listenOptions = {port};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "xo": "^0.45.0"
   },
   "dependencies": {
-    "compression": "^1.7.4",
     "esbuild": "^0.13.4",
     "polka": "^1.0.0-next.22",
     "sirv": "^2.0.2",


### PR DESCRIPTION
Fixes #32. Compression is handled by appengine automatically anyways, so should be redundant