### PR TITLE
Add support for setting esbuild external option

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const files = fileURLToPath(new URL('./files', import.meta.url));
 
 /** @type {import('.')} **/
 export default function entrypoint(options = {}) {
-  const {out = 'build'} = options;
+  const {out = 'build', external = []} = options;
 
   return {
     name: 'appengine',
@@ -47,7 +47,7 @@ export default function entrypoint(options = {}) {
         platform: 'node',
         format: 'cjs',
         sourcemap: 'linked',
-        external: [],
+        external,
       });
 
       writeFileSync(`${out}/package.json`, JSON.stringify({type: 'commonjs'}));


### PR DESCRIPTION
Seeing that other esbuild using adapters provide a way to set the `external` option via adapter options it would probably make sense that this adapter also accepts an option for it. See [adapter-vercel](https://github.com/sveltejs/kit/blob/master/packages/adapter-vercel/index.js#L87) or [adapter-cloudflare](https://github.com/sveltejs/kit/blob/master/packages/adapter-cloudflare/index.js#L39) and [adapter-cloudflare-workers](https://github.com/sveltejs/kit/blob/master/packages/adapter-cloudflare-workers/index.js#L57) which simply pass through all options to esbuild.

Background: a while ago I needed to use a library that would just not work correctly when bundled (it was [polyfill-library](https://www.npmjs.com/package/polyfill-library)). The only option was to provide `external` to esbuild and then adding the library as a dependency in the generated `package.json` in the appengine build output dir.