### PR TITLE
Return 200 OK from /_ah/start

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -47,7 +47,14 @@ function getBase(headers) {
   return `${protocol}://${host}`;
 }
 
+/** @type {import('polka').Middleware} */
+function handleAh(_request, response) {
+  response.statusCode = 200;
+  response.end('OK');
+}
+
 const polkaServer = polka()
+  .get('/_ah/start', handleAh)
   .use(staticServe)
   .use(ssr);
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -27,6 +27,16 @@ describe('Integration test', () => {
       });
   });
 
+  it('return 200 OK from /_ah/start scaling route', done => {
+    chai.request('http://localhost:8080')
+      .get('/_ah/start')
+      .end((error, response) => {
+        expect(response).to.have.status(200);
+        expect(response.text).to.equal('OK');
+        done();
+      });
+  });
+
   it('generates correct app.yaml', () => {
     const path = process.env.TEST_DIR;
     const yaml = fs.readFileSync(path + '/build/app.yaml').toString();


### PR DESCRIPTION
As per #15 - App Engine wants a 200-299 or 404 from this endpoint toconfirm that the app has started correctly; this allows for manual scaling. This middleware is introduced _before_ the Svelte app is mounted, and thus requests are routed straight to Polka.