### PR TITLE
fix: Small appyaml fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,8 @@ export default function entrypoint(options = {}) {
           ...yaml,
           runtime: 'nodejs16',
           entrypoint: 'node index.js',
+          // eslint-disable-next-line camelcase
+          default_expiration: '0h',
           handlers: serverRoutes,
         }),
       );

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ export default function entrypoint(options = {}) {
       builder.rimraf(temporary);
 
       builder.log.minor('Copying assets');
-      builder.writeClient(`${out}/storage`);
-      builder.writePrerendered(`${out}/storage`);
+      builder.writeClient(`${out}/storage${builder.config.kit.paths.base}`);
+      builder.writePrerendered(`${out}/storage${builder.config.kit.paths.base}`);
 
       const relativePath = posix.relative(temporary, builder.getServerDirectory());
 
@@ -56,6 +56,7 @@ export default function entrypoint(options = {}) {
         // eslint-disable-next-line camelcase
         static_files: 'storage/' + page.file,
         upload: 'storage/' + page.file,
+        secure: 'always',
       }));
 
       const prerenderedRedirects = Array.from(builder.prerendered.redirects, ([src, _]) => ({
@@ -80,11 +81,13 @@ export default function entrypoint(options = {}) {
           // eslint-disable-next-line camelcase
           static_dir: `storage/${builder.config.kit.appDir}/immutable`,
           expiration: '30d 0h',
+          secure: 'always',
         },
         {
           url: `/${builder.config.kit.appDir}/`,
           // eslint-disable-next-line camelcase
           static_dir: `storage/${builder.config.kit.appDir}`,
+          secure: 'always',
         },
         {
           url: '/.*',

--- a/tests/expected_app.yaml
+++ b/tests/expected_app.yaml
@@ -8,17 +8,22 @@ handlers:
   - url: //?$
     static_files: storage/index.html
     upload: storage/index.html
+    secure: always
   - url: /about/?$
     static_files: storage/about.html
     upload: storage/about.html
+    secure: always
   - url: /sverdle/how-to-play/?$
     static_files: storage/sverdle/how-to-play.html
     upload: storage/sverdle/how-to-play.html
+    secure: always
   - url: /_app/immutable/
     static_dir: storage/_app/immutable
     expiration: 30d 0h
+    secure: always
   - url: /_app/
     static_dir: storage/_app
+    secure: always
   - url: /.*
     secure: always
     script: auto

--- a/tests/expected_app.yaml
+++ b/tests/expected_app.yaml
@@ -29,3 +29,4 @@ handlers:
     script: auto
 runtime: nodejs16
 entrypoint: node index.js
+default_expiration: 0h


### PR DESCRIPTION
fix: Mark all paths as secure. Fixes #50
fix: Set default expiration to none
The default was 10min by appengine, breaking new deployments for 10 minutes.

