### PR TITLE
fix: Add favicon to app.yaml

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import esbuild from 'esbuild';
 
 const files = fileURLToPath(new URL('files', import.meta.url));
 
-/** @type {import('.')} **/
+/** @type {import('.').default} **/
 export default function entrypoint(options = {}) {
   const {out = 'build', external = []} = options;
 
@@ -20,8 +20,8 @@ export default function entrypoint(options = {}) {
       builder.rimraf(temporary);
 
       builder.log.minor('Copying assets');
-      builder.writeClient(`${out}/storage${builder.config.kit.paths.base}`);
       builder.writePrerendered(`${out}/storage${builder.config.kit.paths.base}`);
+      const clientFiles = builder.writeClient(`${out}/storage${builder.config.kit.paths.base}`);
 
       const relativePath = posix.relative(temporary, builder.getServerDirectory());
 
@@ -75,6 +75,17 @@ export default function entrypoint(options = {}) {
         script: 'auto',
       }));
 
+      // Add yaml entries for all files outside _app directory, such as favicons
+      const additionalClientAssets = clientFiles
+        .filter(file => !file.startsWith('_app/'))
+        .map(file => ({
+          url: '/' + file,
+          // eslint-disable-next-line camelcase
+          static_files: join('storage', file),
+          upload: join('storage', file),
+          secure: 'always',
+        }));
+
       // Load existing app.yaml if it exists
       let yaml = {};
       if (existsSync('app.yaml')) {
@@ -87,6 +98,7 @@ export default function entrypoint(options = {}) {
         ...prerenderedPages,
         ...prerenderedRedirects,
         ...prerenderedAssets,
+        ...additionalClientAssets,
         {
           url: `/${builder.config.kit.appDir}/immutable/`,
           // eslint-disable-next-line camelcase

--- a/tests/expected_app.yaml
+++ b/tests/expected_app.yaml
@@ -22,6 +22,14 @@ handlers:
     upload: storage/test.json
     secure: always
     mime_type: application/json
+  - url: /favicon.png
+    static_files: storage/favicon.png
+    upload: storage/favicon.png
+    secure: always
+  - url: /robots.txt
+    static_files: storage/robots.txt
+    upload: storage/robots.txt
+    secure: always
   - url: /_app/immutable/
     static_dir: storage/_app/immutable
     expiration: 30d 0h


### PR DESCRIPTION
Add assets such as favicon and robot.txt to app yaml to app.yaml as static assets, making sure they get handled by cloud storage instead of appengine
