### PR TITLE
feat: Change default nodejs runtime to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ adapter({
   // These modules will be fetched when the application is deployed
   dependencies: [],
 
-  // Set the Node.js version for the App Engine runtime (default: `16`)
+  // Set the Node.js version for the App Engine runtime (default: `18`)
   // See available runtimes: https://cloud.google.com/appengine/docs/standard/nodejs/runtime
-  nodejsRuntime: 16,
+  nodejsRuntime: 18,
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ type AdapterOptions = {
   /** Dependencies to be added in package.json */
   dependencies?: Record<string, string>;
   /**
-   * Nodejs version to target, defaults to 16
+   * Nodejs version to target, defaults to 18
    * Available runtimes can be seen here:
    * https://cloud.google.com/appengine/docs/standard/nodejs/runtime
    */

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const files = fileURLToPath(new URL('files', import.meta.url));
 
 /** @type {import('.').default} **/
 export default function entrypoint(options = {}) {
-  const {out = 'build', external = [], useCloudLogging = false, useCloudTracing = false, dependencies = {}, nodejsRuntime = 16} = options;
+  const {out = 'build', external = [], useCloudLogging = false, useCloudTracing = false, dependencies = {}, nodejsRuntime = 18} = options;
 
   return {
     name: 'svelte-adapter-appengine',

--- a/tests/expected_app.yaml
+++ b/tests/expected_app.yaml
@@ -40,6 +40,6 @@ handlers:
   - url: /.*
     secure: always
     script: auto
-runtime: nodejs16
+runtime: nodejs18
 entrypoint: node index.js
 default_expiration: 0h


### PR DESCRIPTION
Changing default nodejs runtime to v18 since v16 is reaching end of support. https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#nodejs