### PR TITLE
feat: Change default nodejs runtime to nodejs22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.release_created }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
       - run: npm ci
       - run: npm run lint
   integration:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
       - run: npm ci
       - run: PLATFORM=${{matrix.platform}} tests/test.sh
         shell: bash

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ adapter({
   // These modules will be fetched when the application is deployed
   dependencies: [],
 
-  // Set the Node.js version for the App Engine runtime (default: `18`)
+  // Set the Node.js version for the App Engine runtime (default: `22`)
   // See available runtimes: https://cloud.google.com/appengine/docs/standard/nodejs/runtime
-  nodejsRuntime: 18,
+  nodejsRuntime: 22,
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ export default function entrypoint(options = {}) {
     useCloudLogging = false,
     useCloudTracing = false,
     dependencies = {},
-    nodejsRuntime = 18,
+    nodejsRuntime = 22,
   } = options;
 
   return {

--- a/tests/expected_app.yaml
+++ b/tests/expected_app.yaml
@@ -40,6 +40,6 @@ handlers:
   - url: /.*
     secure: always
     script: auto
-runtime: nodejs18
+runtime: nodejs22
 entrypoint: node index.js
 default_expiration: 0h


### PR DESCRIPTION
Nodejs18 is reaching end of life, so changing the default to nodejs22

Fixes #209 